### PR TITLE
chore(kubebuilder): prep for update

### DIFF
--- a/.github/workflows/update-gitops-promoter-version.yaml
+++ b/.github/workflows/update-gitops-promoter-version.yaml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 
 env:
-  KUBEBUILDER_VERSION: v4.11.1
+  KUBEBUILDER_VERSION: v4.12.0
 
 jobs:
   update-version:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -113,3 +113,6 @@ certManager:
 ##
 prometheus:
   enable: false
+
+webhook:
+  enable: true

--- a/hack/update-artifacthub-crd-annotations.sh
+++ b/hack/update-artifacthub-crd-annotations.sh
@@ -61,7 +61,7 @@ EXAMPLES_DOCS="$TMPDIR/examples_docs.yaml"
 EXAMPLES_ARRAY="$TMPDIR/examples_array.yaml"
 
 # 1) Render CRDs with helm template and build Artifact Hub crds list as a YAML array file
-helm template release "$CHART_DIR_ABS" --set crd.enable=true 2>/dev/null | yq eval-all '
+helm template release "$CHART_DIR_ABS" 2>/dev/null | yq eval-all '
   select(.kind == "CustomResourceDefinition") |
   {
     "kind": .spec.names.kind,


### PR DESCRIPTION
## What

Do not merge yet

The order will be:
1. Create a new release in gitops-promoter
2. Merge this PR
3. Run the update gitops-promoter github action
4. We will need to manually remove  webhook folder it is now place in `extras` folder. 
As you can see in my test https://github.com/emirot/gitops-promoter-helm/pull/3/changes#diff-be3085ee8a8ff0614def6936808f38ba9651cdb9a5974c4b453c8b91e3bf15d5

5. Check if helm chart can install and everything is good and CI passes

Once everything is good, upgrade version of kubebuilder in CI.

## Why

In order to upgrade kubebuilder, they have done multiple bug fixes and improvement in that release
- https://github.com/kubernetes-sigs/kubebuilder/pull/5413/
- https://github.com/kubernetes-sigs/kubebuilder/pull/5422
- https://github.com/kubernetes-sigs/kubebuilder/pull/5392
- https://github.com/kubernetes-sigs/kubebuilder/pull/5472


