### PR TITLE
Chore: add controller configuration

### DIFF
--- a/chart/templates/extra/controllerconfiguration.yaml
+++ b/chart/templates/extra/controllerconfiguration.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
 {{- omit .Values.controllerConfiguration "pullRequest" | toYaml | nindent 2 }}
   pullRequest:
-{{- .Values.controllerConfiguration.pullRequest | toYaml | nindent 4 }}
+{{- omit .Values.controllerConfiguration.pullRequest "template" | toYaml | nindent 4 }}
     template:
       title: "Promote {{ "{{" }} trunc 5 .ChangeTransferPolicy.Status.Proposed.Dry.Sha {{ "}}" }} to `{{ "{{" }} .ChangeTransferPolicy.Spec.ActiveBranch {{ "}}" }}`"
       description: "This PR is promoting the environment branch `{{ "{{" }} .ChangeTransferPolicy.Spec.ActiveBranch {{ "}}" }}` which is currently on dry sha {{ "{{" }} .ChangeTransferPolicy.Status.Active.Dry.Sha {{ "}}" }} to dry sha {{ "{{" }} .ChangeTransferPolicy.Status.Proposed.Dry.Sha {{ "}}" }}."

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -159,6 +159,9 @@ controllerConfiguration:
               fastDelay: "1s"
               slowDelay: "5m"
               maxFastAttempts: 3
+    template:
+      title: "Promote me"
+      description: "This Pr is dope"
     # Due to rendering limitations of Helm
     # the pull request template is defined in the controller configuration manifest directly.
     # This section is still required to set the work queue


### PR DESCRIPTION
Issue: https://github.com/argoproj-labs/gitops-promoter-helm/issues/67
@crenshaw-dev 🙏 

## Summary
Moves the hardcoded ControllerConfiguration spec from the Helm template ([controllerconfiguration.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) into [values.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), making all controller work queue, rate limiter, and reconciler settings user-configurable without forking or patching the chart.

### Motivation
Previously, the ControllerConfiguration resource had its entire spec hardcoded in the template. Users who needed to tune concurrency, requeue durations, or rate limiter settings due to not having the webhook installed were unable to adjust the values. 

### Changes
- Added a new controllerConfiguration section with sensible defaults for all controller work queues (promotionStrategy, changeTransferPolicy, pullRequest, commitStatus, argocdCommitStatus, timedCommitStatus, gitCommitStatus, webRequestCommitStatus), including concurrency, requeue duration, and rate limiter settings.

### Notes
The pull request template block (title + description with Go template expressions) remains hardcoded in the template manifest because Helm's templating would conflict with the promoter's own Go template syntax.
Default values are identical to the previous hardcoded configuration — no behavioral change on upgrade.
