### PR TITLE
Pass Helm values for manager.replicas to deployment

### DIFF
--- a/chart/templates/manager/manager.yaml
+++ b/chart/templates/manager/manager.yaml
@@ -13,7 +13,7 @@ metadata:
     name: {{ include "promoter.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:
-    replicas: 1
+    replicas: {{ .Values.manager.replicas }}
     selector:
         matchLabels:
             control-plane: controller-manager

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,7 +10,7 @@
 ##
 manager:
   replicas: 1
-  
+
   image:
     repository: quay.io/argoprojlabs/gitops-promoter
     tag: v0.26.2


### PR DESCRIPTION
The value field for `manager.replicas` is ignored, since `manager.yaml` is hardcoded to `1`. This allows this value to be overridden.