### PR TITLE
feat: add optional in-cluster dashboard deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ kubectl get promotionstrategydetails -A
 
 See the upstream [Dashboard aggregation API docs](https://github.com/argoproj-labs/gitops-promoter/blob/main/docs/advanced-usage/dashboard-apiserver.md) for details.
 
+## In-cluster dashboard UI
+
+The chart can optionally deploy the GitOps Promoter **dashboard web UI** as an in-cluster
+Deployment + Service, so teams can access a shared, always-available dashboard through their
+own Ingress/Gateway without requiring every user to have local CLI + kubeconfig access.
+It is **disabled by default** and requires the apiserver (above) to be enabled.
+
+Enable it with:
+
+```yaml
+apiserver:
+  enabled: true
+  certs:
+    mode: cert-manager   # or insecure / manual
+dashboard:
+  enabled: true
+```
+
+The dashboard Service listens on port 80 (targeting the container's port 8080). Add your own
+Ingress, Gateway API HTTPRoute, or other routing and authentication resources on top.
+
 ## Known Limitations
 
 ### kube-rbac-proxy image and resources are not configurable

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gitops-promoter
 description: A Helm chart to install GitOps Promoter, a GitOps-native environment promotion tool.
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: 0.32.0
 keywords:
   - kubernetes

--- a/chart/templates/extras/dashboard/_helpers.dashboard.tpl
+++ b/chart/templates/extras/dashboard/_helpers.dashboard.tpl
@@ -1,0 +1,14 @@
+{{/*
+  Resolves the dashboard image, defaulting to the manager image when
+  dashboard.image overrides are not set (the dashboard and controller share one image).
+*/}}
+{{- define "promoter.dashboard.image" -}}
+{{- $img := .Values.dashboard.image | default dict -}}
+{{- $repo := $img.repository | default .Values.manager.image.repository -}}
+{{- $tag := $img.tag | default .Values.manager.image.tag | default .Chart.AppVersion -}}
+{{- if contains "@" $repo -}}
+{{- $repo -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/extras/dashboard/deployment.yaml
+++ b/chart/templates/extras/dashboard/deployment.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  replicas: {{ .Values.dashboard.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: dashboard
+    spec:
+      securityContext:
+        {{- toYaml .Values.dashboard.podSecurityContext | nindent 8 }}
+      containers:
+        - name: dashboard
+          image: {{ include "promoter.dashboard.image" . }}
+          imagePullPolicy: {{ (.Values.dashboard.image).pullPolicy | default .Values.manager.image.pullPolicy }}
+          command:
+            - /usr/bin/tini
+            - "--"
+            - /gitops-promoter
+            - dashboard
+          args:
+            - --port={{ .Values.dashboard.port }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.dashboard.port }}
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.dashboard.securityContext | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.dashboard.resources | nindent 12 }}
+      serviceAccountName: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+      terminationGracePeriodSeconds: 10
+      {{- with .Values.dashboard.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/chart/templates/extras/dashboard/rbac.yaml
+++ b/chart/templates/extras/dashboard/rbac.yaml
@@ -25,6 +25,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/chart/templates/extras/dashboard/rbac.yaml
+++ b/chart/templates/extras/dashboard/rbac.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.dashboard.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+rules:
+  - apiGroups:
+      - view.promoter.argoproj.io
+    resources:
+      - promotionstrategydetails
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - promoter.argoproj.io
+    resources:
+      - promotionstrategies
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/templates/extras/dashboard/service.yaml
+++ b/chart/templates/extras/dashboard/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  selector:
+    app.kubernetes.io/component: dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/chart/templates/extras/dashboard/serviceaccount.yaml
+++ b/chart/templates/extras/dashboard/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "promoter.resourceName" (dict "suffix" "dashboard" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: promoter
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -241,6 +241,66 @@ controllerConfiguration:
 webhook:
   enable: true
 
+## Dashboard web UI deployment.
+## Deploys the dashboard as an in-cluster Deployment + Service so teams can access
+## it through their own Ingress/Gateway without requiring local CLI + kubeconfig.
+## Requires the apiserver (below) to be enabled for the dashboard to function.
+##
+dashboard:
+  ## Enable the in-cluster dashboard UI (Deployment + Service + RBAC).
+  enabled: false
+
+  ## Replica count for the dashboard Deployment.
+  replicas: 1
+
+  ## Image override. Defaults to the manager image (the dashboard and controller share a
+  ## single image). Set repository/tag/pullPolicy to override.
+  image: {}
+    # repository: quay.io/argoprojlabs/gitops-promoter
+    # tag: ""
+    # pullPolicy: IfNotPresent
+
+  ## Port the dashboard listens on inside the container.
+  port: 8080
+
+  ## Resource limits and requests
+  ##
+  resources:
+    limits:
+      cpu: 250m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+  ## Pod-level security settings
+  ##
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+  ## Container-level security settings
+  ##
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  ## Dashboard pod's node selector
+  ##
+  nodeSelector: {}
+
+  ## Dashboard pod's tolerations
+  ##
+  tolerations: []
+
+  ## Dashboard pod's affinity
+  ##
+  affinity: {}
+
 ## Dashboard aggregation apiserver (extension API server backing the GitOps Promoter UI).
 ## Serves the read-only view.promoter.argoproj.io/v1alpha1 PromotionStrategyDetails API
 ## through the Kubernetes aggregation layer. Opt-in; requires a gitops-promoter version


### PR DESCRIPTION
## Summary

- Adds `dashboard.enabled` values toggle to deploy the dashboard UI as an in-cluster Deployment + Service
- Templates follow existing apiserver pattern: ServiceAccount, ClusterRole/Binding, Deployment, Service under `templates/extras/dashboard/`
- Read-only RBAC scoped to `promotionstrategydetails` (view API) and `promotionstrategies`
- Hardened security context (runAsNonRoot, readOnlyRootFilesystem, drop ALL)
- Bumps chart version to 0.12.2

Companion to argoproj-labs/gitops-promoter#1646 (kustomize manifests).

Ref: argoproj-labs/gitops-promoter#1645

## Test plan

- [ ] `helm template --set dashboard.enabled=true` renders all dashboard resources correctly
- [ ] `helm template` (default) renders zero dashboard resources
- [ ] Deploy with `dashboard.enabled=true` + `apiserver.enabled=true` — dashboard pod starts, `/healthz` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)